### PR TITLE
Fixes Wi-Fi status icon from showing off after turning on WiFi card. …

### DIFF
--- a/ClientKit/Api.c
+++ b/ClientKit/Api.c
@@ -76,7 +76,7 @@ bool get_network_list(network_info_list_t *list) {
     if (ioctl_set(IOCTL_80211_SCAN, &scan, sizeof(struct ioctl_scan)) != KERN_SUCCESS) {
         goto error;
     }
-    sleep(3);
+    sleep(2);
     if (get_80211_state(&state) && state == ITL80211_S_RUN) {
         if (get_station_info(&sta_info) == KERN_SUCCESS) {
             current_ssid = (char *)sta_info.ssid;

--- a/HeliPort.xcodeproj/project.pbxproj
+++ b/HeliPort.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		13AF73B624B25E170015867C /* StatusMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA4DFAC243A307B002A862A /* StatusMenu.swift */; };
 		501FA512249B8F77002B5B54 /* WifiPlistManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 501FA511249B8F77002B5B54 /* WifiPlistManager.swift */; };
 		50B86ABA24B22E9B008E4FE4 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 50B86AB824B22E9B008E4FE4 /* Localizable.strings */; };
 		7557CDF424935260000F0F71 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 7557CDF324935260000F0F71 /* Credits.rtf */; };
@@ -14,7 +15,6 @@
 		75FDF38B2481D22000B2A601 /* NetworkInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FDF38A2481D22000B2A601 /* NetworkInfo.swift */; };
 		75FDF38C2481D25A00B2A601 /* Api.c in Sources */ = {isa = PBXBuildFile; fileRef = F8F6CF0B243D675800965B43 /* Api.c */; };
 		BCA4DFAB2438CF25002A862A /* WiFiPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA4DFAA2438CF25002A862A /* WiFiPopoverView.swift */; };
-		BCA4DFAD243A307B002A862A /* StatusMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA4DFAC243A307B002A862A /* StatusMenu.swift */; };
 		BCAF807F243DBA8C0034C8C7 /* JoinPopWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAF807E243DBA8C0034C8C7 /* JoinPopWindow.swift */; };
 		BCCB2AA4243708090005BB82 /* WiFiMenuItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCB2AA3243708090005BB82 /* WiFiMenuItemView.swift */; };
 		BCF712F9243C8BE800BE3C05 /* StatusBarIconManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCF712F8243C8BE800BE3C05 /* StatusBarIconManager.swift */; };
@@ -478,8 +478,8 @@
 				F3915F0724AB1A1B00E6614D /* itl_80211_state+Status.swift in Sources */,
 				BCFA32EB2424D2BE00E23603 /* AppDelegate.swift in Sources */,
 				BCCB2AA4243708090005BB82 /* WiFiMenuItemView.swift in Sources */,
-				BCA4DFAD243A307B002A862A /* StatusMenu.swift in Sources */,
 				75FDF38B2481D22000B2A601 /* NetworkInfo.swift in Sources */,
+				13AF73B624B25E170015867C /* StatusMenu.swift in Sources */,
 				BCAF807F243DBA8C0034C8C7 /* JoinPopWindow.swift in Sources */,
 				F379277424A0DADD0087FF2B /* WifiPopupWindow.swift in Sources */,
 				F34B2B8D24AA4C1E009AB1BB /* NSMenuItem+Extensions.swift in Sources */,

--- a/HeliPort/AppDelegate.swift
+++ b/HeliPort/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         checkDriver()
 
         let statusBar = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        statusBar.button?.image = NSImage.init(named: "WiFiStateDisconnected")
+        statusBar.button?.image = NSImage.init(named: "WiFiStateOff")
         statusBar.button?.image?.isTemplate = true
         statusBar.menu = StatusMenu()
 

--- a/HeliPort/Appearance/StatusBarIconManager.swift
+++ b/HeliPort/Appearance/StatusBarIconManager.swift
@@ -66,6 +66,13 @@ class StatusBarIcon: NSObject {
         }
     }
 
+    class func signalStrength(RSSI: Int16) {
+        timer?.invalidate()
+        timer = nil
+        let signalImage = WifiMenuItemView.getRssiImage(Int(RSSI))
+        statusBar.button?.image = signalImage
+    }
+
     @objc class func tick() {
         DispatchQueue.main.async {
             StatusBarIcon.count -= 1

--- a/HeliPort/Appearance/WiFiMenuItemView.swift
+++ b/HeliPort/Appearance/WiFiMenuItemView.swift
@@ -96,7 +96,7 @@ class WifiMenuItemView: NSView {
             statusImage.isHidden = !networkInfo.isConnected
             ssidLabel.string = networkInfo.ssid
             lockImage.isHidden = networkInfo.auth.security == NetworkInfo.AuthSecurity.NONE.rawValue
-            signalImage.image = getRssiImage(networkInfo.rssi)
+            signalImage.image = WifiMenuItemView.getRssiImage(networkInfo.rssi)
         }
     }
 
@@ -176,7 +176,7 @@ class WifiMenuItemView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func getRssiImage(_ RSSI: Int) -> NSImage? {
+    class func getRssiImage(_ RSSI: Int) -> NSImage? {
         var signalImageName: String
         switch RSSI {
         case ..<(-100):


### PR DESCRIPTION
…(#47)

- Status bar correctly reflects the strength of the connected network.
- closes this issue https://github.com/OpenIntelWireless/HeliPort/issues/46
-  `getRssiImage(_ RSSI: Int) -> NSImage?` is now a class function and can now be called in `StatusBarIconManager` to detect wifi rssi state
- debating whether or not to remove `StatusBarIcon.connecting()` from `NetworkInfo.swift` since the state should be the one figuring that out when is scanning but as of now it is not fixed in itlwm. More info here: https://github.com/OpenIntelWireless/itlwm/issues/160

- Fixed issue where `StatusBarIcon` kept flickering
- set initial `StatusBarIcon` as off so it can be consistent with `isNetworkEnabled`
- only update `StatusBarIcon` from `isNetworkEnabled` if there is a change in value to prevent flickering

- Fixes issue with no items showing when status is `Wi-Fi: Connected`
- checks the state of the network card when the app is first run and sets the correct state https://github.com/OpenIntelWireless/HeliPort/issues/45
- fixed an issue where the network info did not updated when option menu is pressed. Now every time network list updates, it also updates the information of connected network, if any.